### PR TITLE
Add max SOC address for HA charging optimization

### DIFF
--- a/src/powmr-inverter-1.yaml
+++ b/src/powmr-inverter-1.yaml
@@ -616,3 +616,17 @@ select:
       "Solar-Utility-Battery (SUB)": 0
       "Utility-Solar-Battery (USB)": 1
       "Solar-Battery-Utility (SBU)": 2 
+
+# Change max SOC for charge optimisation via HA
+number:
+  - platform: modbus_controller
+    modbus_controller_id: powmr1
+    name: "Set Charge Cut-off SOC"
+    address: 0xE01D
+    register_type: holding
+    value_type: U_WORD
+    min_value: 50
+    max_value: 100
+    step: 1
+    unit_of_measurement: "%"
+    mode: box


### PR DESCRIPTION
I looked up the address for adjusting the maximum SoC in order to implement charging optimisation in Home Assistant.